### PR TITLE
Add 'cross-env' as development dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "autoprefixer": "^9.7.6",
     "browser-sync": "^2.26.7",
     "browser-sync-webpack-plugin": "^2.0.1",
+    "cross-env": "^7.0.2",
     "glider-js": "^1.7.2",
     "laravel-mix": "^5.0.4",
     "postcss-import": "^12.0.1",


### PR DESCRIPTION
_package.json_ scripts use '[cross-env](https://github.com/kentcdodds/cross-env)' package in order to run the commands.

This development package was missing as dependency, leading to an error when trying to run any script.